### PR TITLE
fix: Restoring the PUT case

### DIFF
--- a/Client.cfc
+++ b/Client.cfc
@@ -206,6 +206,11 @@ component
 				}
 				break;
 
+			case "PUT":
+				httpObj.addParam(type="header", name="Content-Type", value="application/json");
+				httpObj.addParam(type="body", value=serializeJSON(arguments.data));
+				break;
+
 		}
 
 		// Append any header data to the HTTP object.


### PR DESCRIPTION
Previous updates have removed the put case in the switch statement
for parsing arguments, this update restores that functionality
